### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     // Lithium compat
     modImplementation "maven.modrinth:lithium:mc1.21.1-0.13.0"
     modCompileOnlyApi "maven.modrinth:omnihopper:2.3.2+1.21"
-    include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
+    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
     include(implementation("com.moulberry:mixinconstraints:1.0.1"))
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     // Lithium compat
     modImplementation "maven.modrinth:lithium:mc1.21.1-0.13.0"
     modCompileOnlyApi "maven.modrinth:omnihopper:2.3.2+1.21"
-    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
+    include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
     include(implementation("com.moulberry:mixinconstraints:1.0.1"))
 }
 


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_