### PR TITLE
feat: prevent overstacking for 1.21.11

### DIFF
--- a/src/main/java/com/github/tatercertified/hopperspeedsimulator/compat/LithiumHopperHelperUtils.java
+++ b/src/main/java/com/github/tatercertified/hopperspeedsimulator/compat/LithiumHopperHelperUtils.java
@@ -9,41 +9,78 @@ import org.jetbrains.annotations.Nullable;
 public final class LithiumHopperHelperUtils {
     public static boolean tryMoveMultipleItems(Inventory to, ItemStack stack, @Nullable Direction fromDirection, int numberOfItems) {
         SidedInventory toSided = to instanceof SidedInventory ? (SidedInventory)to : null;
+        int remaining = Math.min(numberOfItems, stack.getCount());
+        if (remaining <= 0) {
+            return false;
+        }
+        boolean movedAny = false;
         int slot;
         if (toSided != null && fromDirection != null) {
             int[] slots = toSided.getAvailableSlots(fromDirection);
 
             for(slot = 0; slot < slots.length; ++slot) {
-                if (tryMoveMultipleItems(to, toSided, stack, slots[slot], fromDirection, numberOfItems)) {
-                    return true;
+                if (remaining <= 0 || stack.isEmpty()) {
+                    break;
+                }
+                int before = stack.getCount();
+                if (tryMoveMultipleItems(to, toSided, stack, slots[slot], fromDirection, remaining)) {
+                    int moved = before - stack.getCount();
+                    if (moved > 0) {
+                        movedAny = true;
+                        remaining -= moved;
+                    }
                 }
             }
         } else {
             int j = to.size();
 
             for(slot = 0; slot < j; ++slot) {
-                if (tryMoveMultipleItems(to, toSided, stack, slot, fromDirection, numberOfItems)) {
-                    return true;
+                if (remaining <= 0 || stack.isEmpty()) {
+                    break;
+                }
+                int before = stack.getCount();
+                if (tryMoveMultipleItems(to, toSided, stack, slot, fromDirection, remaining)) {
+                    int moved = before - stack.getCount();
+                    if (moved > 0) {
+                        movedAny = true;
+                        remaining -= moved;
+                    }
                 }
             }
         }
 
-        return false;
+        return movedAny;
     }
 
     private static boolean tryMoveMultipleItems(Inventory to, @Nullable SidedInventory toSided, ItemStack transferStack, int targetSlot, @Nullable Direction fromDirection, int numberOfItems) {
         ItemStack toStack = to.getStack(targetSlot);
         if (to.isValid(targetSlot, transferStack) && (toSided == null || toSided.canInsert(targetSlot, transferStack, fromDirection))) {
             if (toStack.isEmpty()) {
-                ItemStack singleItem = transferStack.split(numberOfItems);
+                int maxPerStack = Math.min(transferStack.getMaxCount(), to.getMaxCountPerStack());
+                int moveCount = Math.min(numberOfItems, maxPerStack);
+                moveCount = Math.min(moveCount, transferStack.getCount());
+                if (moveCount <= 0) {
+                    return false;
+                }
+                ItemStack singleItem = transferStack.split(moveCount);
                 to.setStack(targetSlot, singleItem);
                 return true;
             }
 
             int toCount;
             if (toStack.isOf(transferStack.getItem()) && toStack.getMaxCount() > (toCount = toStack.getCount()) && to.getMaxCountPerStack() > toCount && ItemStack.areItemsAndComponentsEqual(toStack, transferStack)) {
-                transferStack.decrement(numberOfItems);
-                toStack.increment(numberOfItems);
+                int maxPerStack = Math.min(toStack.getMaxCount(), to.getMaxCountPerStack());
+                int space = maxPerStack - toCount;
+                if (space <= 0) {
+                    return false;
+                }
+                int moveCount = Math.min(numberOfItems, space);
+                moveCount = Math.min(moveCount, transferStack.getCount());
+                if (moveCount <= 0) {
+                    return false;
+                }
+                transferStack.decrement(moveCount);
+                toStack.increment(moveCount);
                 return true;
             }
         }


### PR DESCRIPTION
This change makes you not to see this warning message spamming on server log.

[04:25:41] [Server thread/WARN]: [net.minecraft.class_2586] Serialization errors:
minecraft:chest // net.minecraft.class_2595@class_2338{x=-501, y=130, z=149}: Failed to append value 'class_11343[slot=15, stack=127 minecraft:gunpowder]' to list 'Items': Value must be within range [1;99]: 127