### PR TITLE
Feature: Command Permission Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,18 @@ Commands:
 ```
 /hopperspeed - gives the current speed
 /hopperspeed default - defaults to the vanilla speed
-/hopperspeed ticks-per-transfer - sets the transfer delay to the specified number of ticks
+/hopperspeed ticks-per-item - sets the transfer delay to the specified number of ticks
 /hopperspeed items-per-transfer - sets the number of items per transfer attempt
 ```
+
+Permission nodes:
+```
+hopperspeed.command.use                 (default OP level: 0)
+hopperspeed.command.default             (default OP level: 2)
+hopperspeed.command.ticks-per-item      (default OP level: 2)
+hopperspeed.command.items-per-transfer  (default OP level: 2)
+```
+
 Compatible with Lithium, FabricAutoCrafter, and many other mods
 
 This mod is *not* compatible with mods that add hoppers with their own item moving logic

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     modImplementation "maven.modrinth:lithium:mc1.21.11-0.21.3-fabric"
     include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.3.3")))
     include(implementation("com.moulberry:mixinconstraints:1.1.0"))
+
+    // Command permissions
+    modImplementation "me.lucko:fabric-permissions-api:0.3.1"
 }
 
 processResources {

--- a/src/main/java/com/github/tatercertified/hopperspeedsimulator/commands/Command.java
+++ b/src/main/java/com/github/tatercertified/hopperspeedsimulator/commands/Command.java
@@ -1,15 +1,18 @@
 package com.github.tatercertified.hopperspeedsimulator.commands;
 
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.function.Predicate;
 
 import static com.github.tatercertified.hopperspeedsimulator.Main.*;
 import static net.minecraft.server.command.CommandManager.argument;
@@ -17,15 +20,21 @@ import static net.minecraft.server.command.CommandManager.literal;
 
 
 public class Command {
+    private static final String PERMISSION_PREFIX = "hopperspeed.command.";
+    private static final int PERMISSION_DEFAULT_OP_LEVEL_USE = 0;
+    private static final int PERMISSION_DEFAULT_OP_LEVEL_EDIT = 2;
 
     public static void registerCommand() throws FileNotFoundException {
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated, environment) -> dispatcher.register(CommandManager.literal("hopperspeed")
+                        .requires(perm("use", PERMISSION_DEFAULT_OP_LEVEL_USE))
                         .executes(context -> {
                             context.getSource().sendFeedback(() -> Text.of("Current speed is "+ ticks +" ticks, with "+ items +" items per transfer"), true);
                             return 1;
                         })
 
-                .then(literal("ticks-per-item").then(argument("ticks-per-item", IntegerArgumentType.integer()).executes(context -> {
+                .then(literal("ticks-per-item")
+                        .requires(perm("ticks-per-item", PERMISSION_DEFAULT_OP_LEVEL_EDIT))
+                        .then(argument("ticks-per-item", IntegerArgumentType.integer()).executes(context -> {
                     properties.setProperty("ticks-per-transfer", String.valueOf(IntegerArgumentType.getInteger(context, "ticks-per-item")));
                     try (OutputStream output = Files.newOutputStream(FabricLoader.getInstance().getConfigDir().resolve("hopperspeedsim.properties"))) {
                         properties.store(output, null);
@@ -37,7 +46,9 @@ public class Command {
                     return 1;
                 })))
 
-                .then(literal("default").executes(context -> {
+                .then(literal("default")
+                        .requires(perm("default", PERMISSION_DEFAULT_OP_LEVEL_EDIT))
+                        .executes(context -> {
                     properties.setProperty("ticks-per-transfer", "8");
                     properties.setProperty("items-per-transfer", "1");
                     try (OutputStream output = Files.newOutputStream(FabricLoader.getInstance().getConfigDir().resolve("hopperspeedsim.properties"))) {
@@ -51,7 +62,9 @@ public class Command {
                     return 1;
                 }))
 
-                .then(literal("items-per-transfer").then(argument("items-per-transfer", IntegerArgumentType.integer()).executes(context -> {
+                .then(literal("items-per-transfer")
+                        .requires(perm("items-per-transfer", PERMISSION_DEFAULT_OP_LEVEL_EDIT))
+                        .then(argument("items-per-transfer", IntegerArgumentType.integer()).executes(context -> {
                     properties.setProperty("items-per-transfer", String.valueOf(IntegerArgumentType.getInteger(context, "items-per-transfer")));
                             try (OutputStream output = Files.newOutputStream(FabricLoader.getInstance().getConfigDir().resolve("hopperspeedsim.properties"))) {
                                 properties.store(output, null);
@@ -63,5 +76,9 @@ public class Command {
                     return 1;
                 }
                 )))));
+    }
+
+    private static Predicate<ServerCommandSource> perm(String nodeSuffix, int defaultOpLevel) {
+        return Permissions.require(PERMISSION_PREFIX + nodeSuffix, defaultOpLevel);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,7 @@
   "depends": {
     "fabricloader": ">=0.14.8",
     "fabric": "*",
+    "fabric-permissions-api-v0": "*",
     "minecraft": ">=1.21.3"
   }
 }


### PR DESCRIPTION
I added permission node for issue #3 
Now we have:

| Command                            | Permission                      | Default OP Level |
|------------------------------------|--------------------------------------------------------------------------------|---------------------------------|
| /hopperspeed                                | hopperspeed.command.use                           | 0        |
| /hopperspeed default                    | hopperspeed.command.default                     | 2        |
| /hopperspeed ticks-per-item        | hopperspeed.command.ticks-per-item          | 2        |
| /hopperspeed items-per-transfer | hopperspeed.command.items-per-transfer    | 2        |